### PR TITLE
have end-to-end test use random available domain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ CLEAN_DIRS := $(CLEAN_DIRS)
 DOMAINS := $(shell find . -mindepth 3 -maxdepth 3 -name domain.yaml \
 	-exec dirname {} \; | awk -F/ '{print $$NF}')
 
+TEST_DOMAIN := $(word $(shell echo | awk '{print 1+int(rand()*$(words $(DOMAINS)))}'), $(DOMAINS))
+
 distclean: clean_docker clean_markers
 
 $(MARKERS):
@@ -216,12 +218,12 @@ clean: clean-$(1)
 endef
 
 .PHONY: build-end-to-end-test
-build-end-to-end-test: artworld-stl-release
+build-end-to-end-test: $(TEST_DOMAIN)-stl-release
 	docker build -t chronicle-test:$(ISOLATION_ID) -f docker/chronicle-test/chronicle-test.dockerfile .
 
 .PHONY: test-e2e
 test-e2e: build-end-to-end-test
-	CHRONICLE_IMAGE=chronicle-artworld-stl-release \
+	CHRONICLE_IMAGE=chronicle-$(TEST_DOMAIN)-stl-release \
 	CHRONICLE_VERSION=$(ISOLATION_ID) \
 	CHRONICLE_TP_IMAGE=$(CHRONICLE_TP_IMAGE) \
 	CHRONICLE_TP_VERSION=$(CHRONICLE_VERSION) \

--- a/docker/chronicle.dockerfile
+++ b/docker/chronicle.dockerfile
@@ -24,7 +24,7 @@ RUN if [ "${RELEASE}" = "yes" ]; then \
 FROM cache as builder
 ARG RELEASE=no
 ARG FEATURES=""
-ARG DOMAIN=artworld
+ARG DOMAIN
 
 COPY domains/${DOMAIN}/domain.yaml crates/chronicle-domain/domain.yaml
 RUN /usr/local/bin/chronicle-domain-lint crates/chronicle-domain/domain.yaml


### PR DESCRIPTION
Resolves CHRON-302 and removes last vestiges of the artworld domain. Companion to https://github.com/btpworks/chronicle-examples/pull/82.

In the likely case of exactly one domain being available, of course that is the domain that will be used for the testing.