### PR TITLE
Don't provide `--unlock-cors` option.

### DIFF
--- a/docker/chronicle-domain.yaml
+++ b/docker/chronicle-domain.yaml
@@ -27,8 +27,7 @@ services:
         --console-logging pretty \
         --remote-database \
         serve-graphql \
-        --interface 0.0.0.0:9982 \
-        --unlock-cors
+        --interface 0.0.0.0:9982
     expose:
       - 9982
     ports:


### PR DESCRIPTION
The GraphQL playground is now opened automatically if no auth endpoint is set.

# PR Checklist

## Please complete this checklist after opening your PR

* [x] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [ ] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)
