### PR TITLE
pass variables from environment file into chronicle environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ $(MARKERS):
 	mkdir -p $(MARKERS)
 
 DOCKER_COMPOSE := docker-compose
+DOCKER_COMPOSE_ENV ?= chronicle-environment
 DOCKER_BUILD := docker buildx build
 DOCKER_TAG := docker tag
 
@@ -182,7 +183,10 @@ $(1)-sdl: domains/$(1)/chronicle.graphql
 
 .PHONY: run-$(1)
 run-$(1): $(1)-inmem-debug
-	-CHRONICLE_IMAGE=chronicle-$(1)-inmem CHRONICLE_VERSION=$(ISOLATION_ID) $(DOCKER_COMPOSE) -f ./docker/chronicle-domain.yaml up --force-recreate
+	export CHRONICLE_IMAGE=chronicle-$(1)-inmem; \
+	export CHRONICLE_VERSION=$(ISOLATION_ID); \
+	export CHRONICLE_ENV_FILE=$(DOCKER_COMPOSE_ENV); \
+	$(DOCKER_COMPOSE) -f ./docker/chronicle-domain.yaml up --force-recreate
 
 .PHONY: run-stl-$(1)
 run-stl-$(1): $(1)-stl-debug
@@ -190,6 +194,7 @@ run-stl-$(1): $(1)-stl-debug
 	export CHRONICLE_TP_IMAGE=$(CHRONICLE_TP_IMAGE); \
 	export CHRONICLE_VERSION=$(ISOLATION_ID); \
 	export CHRONICLE_TP_VERSION=$(CHRONICLE_VERSION); \
+	export CHRONICLE_ENV_FILE=$(DOCKER_COMPOSE_ENV); \
 	$(DOCKER_COMPOSE) -f docker/chronicle.yaml up --force-recreate -d
 
 .PHONY: stop-stl-$(1)

--- a/docker/chronicle-domain.yaml
+++ b/docker/chronicle-domain.yaml
@@ -11,6 +11,7 @@ services:
       - "5432:5432"
 
   domain:
+    env_file: "${CHRONICLE_ENV_FILE}"
     environment:
       - RUST_BACKTRACE=full
       - RUST_LOG=trace,cranelift_codegen=off,wasmtime_jit=off,wasmtime_cranelift=off,regalloc2::ion=off,cranelift_wasm=off

--- a/docker/chronicle.yaml
+++ b/docker/chronicle.yaml
@@ -106,6 +106,7 @@ services:
   #Chronicle API initialization is delayed as it needs opa-init to have placed a
   #policy on-chain
   chronicle-sawtooth-api:
+    env_file: "${CHRONICLE_ENV_FILE}"
     environment:
       - RUST_BACKTRACE=full
       - RUST_LOG=info,cranelift_codegen=off,wasmtime_cranelift=off,regalloc2::ion=off,cranelift_wasm=off


### PR DESCRIPTION
Passes environment variable values from `docker/chronicle-environment` to the running Chronicle. The name of this file (if relative, then to `docker/`) can be set in `DOCKER_COMPOSE_ENV`.

# PR Checklist

## Please complete this checklist after opening your PR

* [ ] I have updated documentation as necessary
* [x] I have updated helm chart(s) if needed
* [x] I have added tests if needed
* [x] All new and existing tests are passing
* [x] Any breaking changes are clearly flagged and documented
* [x] I’ve included a link to any relevant ticket(s)
